### PR TITLE
Specify plotsize for UnicodePlots.lineplot in show

### DIFF
--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -138,7 +138,12 @@ function Base.show(io::IO, o::UnivariateASH)
     println(io, "  >       m: ", o.m)
     println(io, "  >   edges: ", o.rng)
     println(io, "  >    nobs: ", StatsBase.nobs(o))
-    maximum(o.y) > 0 && show(io, UnicodePlots.lineplot(xy(o)...))
+    if maximum(o.y) > 0
+      x, y = xy(o)
+      xlim = [minimum(x), maximum(x)]
+      ylim = [0, maximum(y)]
+      show(io, UnicodePlots.lineplot(x, y, xlim=xlim, ylim=ylim, height=10, width=40))
+    end
 end
 
 StatsBase.nobs(o::ASH) = o.n


### PR DESCRIPTION
I very recently increased the default size of the plot windows in UnicodePlots.

This PR should provide a more stable experience by explicitly setting the plot size and by squeezing the plot limits.