### PR TITLE
Fancy `show` only in multi-line context.

### DIFF
--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -10,7 +10,7 @@ mutable struct Ash{R <: AbstractRange, F <: Function}
         new{R, F}(zeros(Float64, length(rng)), rng, zeros(Int, length(rng)), kernel, m, 0)
     end
 end
-function Base.show(io::IO, o::Ash)
+function Base.show(io::IO, ::MIME"text/plain", o::Ash)
     println(io, "Ash")
     f, l, s = round.((first(o.rng), last(o.rng), step(o.rng)), digits=4)
     println(io, "  > edges  | $f : $s : $l")


### PR DESCRIPTION
This avoids a wall of histogram plots when printing an array of `Ash`es.
before:
```
julia> a = [ash(randn(20)) for _=1:4]
4-element Array{AverageShiftedHistograms.Ash{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},typeof(AverageShiftedHistograms.Kernels.biweight)},1}:
 Ash
  > edges  | -1.9128 : 0.0094 : 2.7804
  > kernel | biweight
  > m      | 5
  > nobs   | 20
     ┌────────────────────────────────────────┐ 
   3 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⣸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀⠀⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡇⡀⢀⠀⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡇⡇⢸⠀⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡇⣧⢸⠀⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⣷⡇⠀⠀⢸⠀⢸⢸⡇⣿⣿⢸⢸⣾⣸⠀⣷⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⣷⠀⣷⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⣿⡇⠀⠀⢸⠀⣿⢸⡇⣿⡟⣼⢸⣿⣿⠀⣿⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⣿⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⣿⣧⠀⠀⢸⡇⣿⢸⣷⢹⡇⣿⢸⣿⣿⠀⣿⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⣿⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⣿⣿⠀⠀⢸⡇⣿⢸⣿⢸⡇⣿⠸⣿⣿⠀⣿⠀⢀⢿⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⣿⠀⠀⠀⠀⠀│ 
   0 │⠀⠀⠀⠀⠛⠘⠒⠒⠚⠓⠛⠚⠛⠘⠃⠛⠀⠛⠛⠒⠛⠒⠚⠘⠒⠒⠒⠒⠒⠒⠒⠒⠛⠒⠋⠀⠀⠀⠀⠀│ 
     └────────────────────────────────────────┘
     -2                                       3
 Ash
  > edges  | -2.3479 : 0.0082 : 1.7546
  > kernel | biweight
  > m      | 5
  > nobs   | 20
     ┌────────────────────────────────────────┐
   3 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣦⠀⠀⠀⠀⠀⢸⠀⠀⠀⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⠀⠀⠀⠀⢸⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⠀⠀⠀⠀⢸⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⠀⠀⠀⠀⢸⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⡀⠀⣿⠀⠀⠀⠀⠀⢸⡀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⣴⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢰⡆⢸⡇⡆⣿⠀⣴⠀⡆⠀⢸⣷⡆⠀⣷⠀⣦⣦⣦⠀⠀⣶⠀⠀⠀⠀⠀⠀│ 
     │⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡸⡇⢸⡇⡇⣿⠀⣿⠀⣧⠀⢸⣿⢻⠀⣿⠀⣿⣿⣿⠀⠀⣿⠀⠀⠀⠀⠀⠀│ 
     │⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⡇⡸⡇⡇⣿⠀⣿⠀⣿⠀⢸⣿⢸⢰⢹⠀⣿⣿⣿⠀⠀⣿⠀⠀⠀⠀⠀⠀│ 
     │⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⡇⡇⡇⣷⣿⠀⣿⠀⣿⠀⡇⣿⢸⢸⢸⠀⣿⣿⣿⠀⠀⣿⠀⠀⠀⠀⠀⠀│
     │⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⡇⡇⣷⢹⣿⠀⣿⠀⣿⠀⡇⣿⢸⢸⢸⠀⣿⣿⣿⠀⠀⣿⠀⠀⠀⠀⠀⠀│ 
   0 │⠛⠒⠒⠒⠒⠒⠒⠒⠒⠒⠒⠃⠓⠃⠛⠘⠛⠒⠛⠒⠛⠒⠃⠛⠘⠚⠘⠒⠛⠛⠛⠒⠒⠋⠀⠀⠀⠀⠀⠀│ 
     └────────────────────────────────────────┘
     -2                                       2
 Ash
  > edges  | -3.2508 : 0.0105 : 1.9918
  > kernel | biweight
  > m      | 5
  > nobs   | 20
     ┌────────────────────────────────────────┐
   2 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⠀⠀⠀⢠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣸⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⠀⠀⠀⠀⠀⣼⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⠀⠀⠀⠀⠀⡟⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠀⠀⠀⠀⠀⠀⡇⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⣆⠀⢰⠀⡆⠀⠀⠀⠀⣆⠀⠀⠀⠀⡆⠀⣿⢰⠀⠀⣶⣰⣰⡇⣷⡄⠀⢠⡆⠀⢰⠀⠀⣦⠀⠀⠀⠀│ 
     │⠀⠀⣿⠀⣸⠀⡇⠀⠀⠀⠀⣿⠀⠀⠀⠀⡇⠀⣿⢸⠀⠀⡿⣿⣿⡇⣿⡇⠀⢸⡇⠀⢸⠀⠀⣿⠀⠀⠀⠀│ 
     │⠀⠀⣿⠀⣿⠀⣇⠀⠀⠀⠀⣿⠀⠀⠀⢸⡇⢰⢹⢸⠀⠀⡇⣿⣿⡇⣿⡇⠀⢸⡇⠀⢸⠀⠀⣿⠀⠀⠀⠀│ 
     │⠀⠀⣿⠀⣿⠀⣿⠀⠀⠀⠀⣿⠀⠀⠀⢸⡇⢸⢸⢸⠀⠀⡇⣿⣿⡇⣿⡇⠀⢸⡇⠀⢸⡆⠀⣿⠀⠀⠀⠀│ 
     │⠀⠀⣿⠀⣿⠀⣿⠀⠀⠀⠀⣿⠀⠀⠀⢸⡇⢸⢸⡜⡇⠀⡇⣿⣿⡇⣿⡇⠀⢸⡇⠀⢸⡇⠀⣿⠀⠀⠀⠀│ 
     │⠀⠀⣿⠀⣿⢀⢿⠀⠀⠀⠀⣿⠀⠀⠀⢸⡇⢸⠀⡇⡇⠀⡇⢻⣿⡇⣿⡇⠀⢸⡇⠀⡇⡇⠀⣿⠀⠀⠀⠀│
   0 │⠀⠀⠉⠉⠉⠉⠈⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠀⠁⠉⠉⠁⠈⠉⠁⠉⠉⠉⠉⠉⠉⠁⠉⠉⠉⠀⠀⠀⠀│ 
     └────────────────────────────────────────┘ 
     -3                                       2
 Ash
  > edges  | -1.8611 : 0.0081 : 2.1574
  > kernel | biweight
  > m      | 5
  > nobs   | 20
     ┌────────────────────────────────────────┐ 
   2 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⠀⠀⠀⠀⠀⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⠀⠀⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⠀⠀⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⢰⠀⣆⢰⢰⣶⢰⣸⠀⠀⠀⠀⠀⣿⢰⠀⢰⣰⠀⢰⢰⡆⡆⠀⣰⡆⠀⠀⠀⠀⠀⠀⡆⠀⠀│ 
     │⠀⠀⠀⠀⠀⢸⠀⣿⢸⢸⣿⣼⡏⡆⠀⠀⠀⠀⣿⢸⠀⢸⣿⠀⢸⢸⡇⡇⠀⣿⡇⠀⠀⠀⠀⠀⠀⡇⠀⠀│
     │⠀⠀⠀⠀⠀⢸⠀⣿⢸⢸⣿⣿⡇⡇⠀⠀⠀⠀⣿⢸⠀⢸⣿⠀⢸⢸⣧⡇⠀⣿⡇⠀⠀⠀⠀⠀⢠⡇⠀⠀│ 
     │⠀⠀⠀⠀⠀⢸⡄⣿⢸⢸⣿⣿⡇⡇⠀⠀⠀⠀⣿⢸⠀⢸⣿⠀⢸⢸⣿⡇⠀⣿⡇⠀⠀⠀⠀⠀⢸⡇⠀⠀│
     │⠀⠀⠀⠀⠀⢸⡇⣿⢸⣾⣿⣿⡇⡇⠀⠀⠀⢀⢿⢸⠀⢸⣿⠀⢸⢸⢻⡇⠀⡟⡇⠀⠀⠀⠀⠀⢸⡇⠀⠀│ 
     │⠀⠀⠀⠀⠀⢸⡇⣿⢸⣿⣿⣿⡇⡇⠀⠀⠀⢸⢸⡸⡀⢸⣿⠀⡼⣸⢸⡇⠀⡇⡇⠀⠀⠀⠀⠀⢸⡇⠀⠀│ 
     │⠀⠀⠀⠀⠀⢸⡇⣿⢸⣿⣿⣿⠇⡇⠀⠀⠀⢸⢸⡇⡇⢸⢿⠀⡇⣿⢸⢸⠀⡇⡇⠀⠀⠀⠀⠀⢸⡇⠀⠀│
     │⠀⠀⠀⠀⠀⡸⣇⣿⡎⣿⣿⣿⠀⣇⣀⣀⣀⣸⢸⡇⣇⣸⢸⣀⡇⡇⢸⢸⣀⡇⣇⣀⣀⣀⣀⣀⣸⠇⠀⠀│ 
   0 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     └────────────────────────────────────────┘
     -2                                       2
```
after:
```
julia> a
4-element Array{AverageShiftedHistograms.Ash{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},typeof(AverageShiftedHistograms.Kernels.biweight)},1}:
 AverageShiftedHistograms.Ash{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},typeof(AverageShiftedHistograms.Kernels.biweight)}([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], -2.546385667444406:0.008965048221625102:1.9271733951465202, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0  …  0, 0, 0, 0, 0, 0, 0, 0, 0, 0], AverageShiftedHistograms.Kernels.biweight, 5, 20)
 AverageShiftedHistograms.Ash{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},typeof(AverageShiftedHistograms.Kernels.biweight)}([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], -2.4127793509880773:0.012455236648550779:3.8023837366387614, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0  …  0, 0, 0, 0, 0, 0, 0, 0, 0, 0], AverageShiftedHistograms.Kernels.biweight, 5, 20)
 AverageShiftedHistograms.Ash{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},typeof(AverageShiftedHistograms.Kernels.biweight)}([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], -2.278329520890612:0.00694665975661607:1.1880536976608072, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0  …  0, 0, 0, 0, 0, 0, 0, 0, 0, 0], AverageShiftedHistograms.Kernels.biweight, 5, 20)
 AverageShiftedHistograms.Ash{StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}},typeof(AverageShiftedHistograms.Kernels.biweight)}([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], -2.044676756311979:0.008532115495315446:2.2128488758504288, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0  …  0, 0, 0, 0, 0, 0, 0, 0, 0, 0], AverageShiftedHistograms.Kernels.biweight, 5, 20)

julia> a[1]
Ash
  > edges  | -2.5464 : 0.009 : 1.9272
  > kernel | biweight
  > m      | 5
  > nobs   | 20
     ┌────────────────────────────────────────┐ 
   3 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⢠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⢸⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
     │⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⣾⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀⣿⠀⠀⠀⠀⠀⡀⢀⠀⣀⢀⢀⢀⡀⠀⣀⣀⢀⠀⢀⡀⠀⢀⡀⡀⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀⣿⠀⠀⠀⠀⠀⡇⢸⡇⣿⢸⣾⣿⡇⠀⣿⣿⢸⠀⢸⡇⠀⢸⣿⡇⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀⣿⠀⠀⠀⠀⠀⡇⢸⡇⣿⣸⣿⣿⡇⠀⣿⣿⢸⡇⢸⡇⠀⢸⣿⡇⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⠀⣿⠀⠀⠀⠀⢰⡇⢸⣧⣿⣿⣿⣿⡇⠀⣿⣿⢸⡇⢸⡇⠀⢸⣿⡇⠀⠀⠀⠀│ 
     │⠀⠀⠀⠀⠀⠀⠀⢸⡇⠀⣀⠿⢄⣀⡀⠀⢸⡇⢸⣿⣿⣿⣿⠿⡇⠀⣿⢿⢸⡇⢸⡇⠀⡸⣿⢧⠀⠀⠀⠀│ 
   0 │⠀⠀⠀⠀⠀⠀⠀⠘⠋⠉⠀⠀⠀⠀⠈⠉⠚⠓⠚⠛⠛⠛⠛⠀⠓⠒⠛⠘⠚⠓⠚⠓⠒⠃⠛⠈⠀⠀⠀⠀│ 
     └────────────────────────────────────────┘
     -3                                       2
```