### PR TITLE
Use DensityInterface.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "77b51b56-6f8f-5c3a-9cb4-d71f9594ea6e"
 version = "0.8.8"
 
 [deps]
+DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -10,6 +11,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
+DensityInterface = "0.4"
 RecipesBase = "0.7, 0.8, 1.0, 1.1"
 StatsBase = "0.32, 0.33"
 UnicodePlots = "1.1, 2.0, 2.1, 2.2, 2.3, 2.4, 3"

--- a/src/AverageShiftedHistograms.jl
+++ b/src/AverageShiftedHistograms.jl
@@ -3,7 +3,8 @@ module AverageShiftedHistograms
 import UnicodePlots, RecipesBase
 using LinearAlgebra, Statistics
 import StatsBase: nobs, fweights
-export ash, ash!, extendrange, xy, xyz, nout, nobs, Kernels
+import DensityInterface: logpdf, pdf
+export ash, ash!, extendrange, xy, xyz, nout, nobs, Kernels, logpdf, pdf
 
 
 #-----------------------------------------------------------------------# common

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -156,18 +156,18 @@ function Base.extrema(o::Ash)
 end
 
 """
-    pdf(o::Ash, x::Real)
+    logpdf(o::Ash, x::Real)
 
 Return the estimated density at the point `x`.
 """
-function pdf(o::Ash, x::Real)
+function DensityInterface.logpdf(o::Ash, x::Real)
     rng = o.rng
     y = o.density
     i = searchsortedlast(rng, x)
     if 1 <= i < length(rng)
-        y[i] + (y[i+1] - y[i]) * (x - rng[i]) / (rng[i+1] - rng[i])
+        log(y[i]) + (log(y[i+1]) - log(y[i])) * (x - rng[i]) / (rng[i+1] - rng[i]))
     else
-        0.0
+        -inf
     end
 end
 


### PR DESCRIPTION
The PDF function should overload DensityInterface.jl's `logpdf` for a consistent interface. (`pdf` is then defined as `exp(logpdf)`.)