### PR TITLE
Weights for Univariates

### DIFF
--- a/src/AverageShiftedHistograms.jl
+++ b/src/AverageShiftedHistograms.jl
@@ -3,7 +3,7 @@ module AverageShiftedHistograms
 import UnicodePlots, RecipesBase
 using LinearAlgebra, Statistics
 import StatsBase: nobs, fweights
-export ash, ash!, extendrange, xy, xyz, nout, nobs, Kernels
+export ash, ashw, ash!, ashw!, extendrange, xy, xyz, nout, nobs, Kernels
 
 
 #-----------------------------------------------------------------------# common

--- a/src/AverageShiftedHistograms.jl
+++ b/src/AverageShiftedHistograms.jl
@@ -3,7 +3,7 @@ module AverageShiftedHistograms
 import UnicodePlots, RecipesBase
 using LinearAlgebra, Statistics
 import StatsBase: nobs, fweights
-export ash, ashw, ash!, ashw!, extendrange, xy, xyz, nout, nobs, Kernels
+export ash, ash!, extendrange, xy, xyz, nout, nobs, Kernels
 
 
 #-----------------------------------------------------------------------# common

--- a/src/AverageShiftedHistograms.jl
+++ b/src/AverageShiftedHistograms.jl
@@ -2,7 +2,7 @@ module AverageShiftedHistograms
 
 import UnicodePlots, RecipesBase
 using LinearAlgebra, Statistics
-import StatsBase: nobs, fweights
+import StatsBase: nobs, fweights, AbstractWeights
 export ash, ash!, extendrange, xy, xyz, nout, nobs, Kernels
 
 

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -120,20 +120,14 @@ Ash objectes can be updated with new data, new weights(only for univariates), sm
     ash!(obj, newx, newy; kw...)
 
 """
-function ash(x; nbin=500, rng::AbstractRange = extendrange(x, nbin), m = ceil(Int, length(rng)/100), kernel = Kernels.biweight)
+function ash(x; weight=nothing, nbin=500, rng::AbstractRange = extendrange(x, nbin), m = ceil(Int, length(rng)/100), kernel = Kernels.biweight)
     o = Ash(rng, kernel, m)
-    _histogram!(o, x)
-    _ash!(o)
-end
-
-function ashw(x; weight=nothing, nbin=500, rng::AbstractRange = extendrange(x, nbin), m = ceil(Int, length(rng)/100), kernel = Kernels.biweight)
     if weight === nothing
-        ash(x; nbin = nbin, rng = rng, m = m, kernel = kernel)
+        _histogram!(o, x)
     else
-        o = Ash(rng, kernel, m)
         _weightedhistogram!(o, x, weight)
-        _ash!(o)
     end
+    _ash!(o)
 end
 
 
@@ -149,21 +143,15 @@ function ash!(o::Ash; m = o.m, kernel = o.kernel)
     o.kernel = kernel
     _ash!(o)
 end
-function ash!(o::Ash, y; m = o.m, kernel = o.kernel)
+function ash!(o::Ash, y; weight=nothing,  m = o.m, kernel = o.kernel)
     o.m = m
     o.kernel = kernel
-    _histogram!(o, y)
-    _ash!(o)
-end
-function ashw!(o::Ash, y; weight=nothing, m = o.m, kernel = o.kernel)
     if weight === nothing
-        ash!(o, y; m = m, kernel = kernel)
+        _histogram!(o, y)
     else
-        o.m = m
-        o.kernel = kernel
         _weightedhistogram!(o, y, weight)
-        _ash!(o)
     end
+    _ash!(o)
 end
 
 function Base.merge!(o::Ash, o2::Ash)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,19 +109,18 @@ end
 
 @testset "AshWeighted" begin
     x = randn(10_000)
-    o = ashw(x; weight = ones(21), rng = -1:0.1:1)
+    o = ash(x; weight = ones(21), rng = -1:0.1:1)
     o2 = ash(x; rng = -1:0.1:1)
-    o3 = ashw(x; rng = -1:0.1:1)
-    @test o == o2 == o3
+    @test o == o2
 
     y = rand(1000)
     w = rand(1:10, 11)
     o = ash(y; rng = 0:0.1:1)
-    ow = ashw(y; weight = w, rng = 0:0.1:1)
+    ow = ash(y; weight = w, rng = 0:0.1:1)
     @test o.counts .* w == ow.counts
 
     w = rand(1:10, 10)
-    @test_throws DimensionMismatch ashw(y; weight = w, rng = 0:0.1:1)
+    @test_throws DimensionMismatch ash(y; weight = w, rng = 0:0.1:1)
     
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,20 +108,23 @@ end
 end
 
 @testset "AshWeighted" begin
-    x = randn(10_000)
-    o = ash(x; weight = ones(21), rng = -1:0.1:1)
-    o2 = ash(x; rng = -1:0.1:1)
-    @test o == o2
+    weight_funcs = (weights, aweights, fweights, pweights)
 
-    y = rand(1000)
-    w = rand(1:10, 11)
-    o = ash(y; rng = 0:0.1:1)
-    ow = ash(y; weight = w, rng = 0:0.1:1)
-    @test o.counts .* w == ow.counts
+    for f in weight_funcs
+        x = randn(10_000)
+        o = ash(x, f(ones(21)), rng = -1:0.1:1)
+        o2 = ash(x; rng = -1:0.1:1)
+        @test o == o2
 
-    w = rand(1:10, 10)
-    @test_throws DimensionMismatch ash(y; weight = w, rng = 0:0.1:1)
-    
+        y = rand(1000)
+        w = f(rand(1:10, 11))
+        o = ash(y; rng = 0:0.1:1)
+        ow = ash(y, w; rng = 0:0.1:1)
+        @test o.counts .* w == ow.counts
+
+        w = f(rand(1:10, 10))
+        @test_throws DimensionMismatch ash(y, w; rng = 0:0.1:1)
+    end 
 end
 
 end #module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,18 +109,19 @@ end
 
 @testset "AshWeighted" begin
     x = randn(10_000)
-    o = ashw(x, ones(21); rng = -1:0.1:1)
+    o = ashw(x; weight = ones(21), rng = -1:0.1:1)
     o2 = ash(x; rng = -1:0.1:1)
-    @test o == o2
+    o3 = ashw(x; rng = -1:0.1:1)
+    @test o == o2 == o3
 
     y = rand(1000)
     w = rand(1:10, 11)
     o = ash(y; rng = 0:0.1:1)
-    ow = ashw(y, w; rng = 0:0.1:1)
+    ow = ashw(y; weight = w, rng = 0:0.1:1)
     @test o.counts .* w == ow.counts
 
     w = rand(1:10, 10)
-    @test_throws DimensionMismatch ashw(y, w; rng = 0:0.1:1)
+    @test_throws DimensionMismatch ashw(y; weight = w, rng = 0:0.1:1)
     
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,4 +107,21 @@ end
     xyz(o)
 end
 
+@testset "AshWeighted" begin
+    x = randn(10_000)
+    o = ashw(x, ones(21); rng = -1:0.1:1)
+    o2 = ash(x; rng = -1:0.1:1)
+    @test o == o2
+
+    y = rand(1000)
+    w = rand(1:10, 11)
+    o = ash(y; rng = 0:0.1:1)
+    ow = ashw(y, w; rng = 0:0.1:1)
+    @test o.counts .* w == ow.counts
+
+    w = rand(1:10, 10)
+    @test_throws DimensionMismatch ashw(y, w; rng = 0:0.1:1)
+    
+end
+
 end #module


### PR DESCRIPTION
This PR partially addresses #23 and adds weights for univariate average-shifted histograms.
Jobs done:
* Create a new function `ashw` for univariate weighted average-shifted histograms
* Add tests for them
* Update the documentation